### PR TITLE
Remove unused variables to fix linter failing build

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -5,10 +5,8 @@ import {
   NavigationMenu,
   NavigationMenuContent,
   NavigationMenuItem,
-  NavigationMenuLink,
   NavigationMenuList,
   NavigationMenuTrigger,
-  navigationMenuTriggerStyle,
 } from "./navigation-menu";
 import IncomeMenuContent from './IncomeMenuContent';
 


### PR DESCRIPTION
Linter was causing frontend build to fail. Remove unused variables.