### PR TITLE
PFA-25 Database schema for expenses

### DIFF
--- a/backend/models/Expense.ts
+++ b/backend/models/Expense.ts
@@ -1,0 +1,135 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+// Constants for dropdowns and validation
+export const EXPENSE_CATEGORIES = [
+    'Housing',
+    'Transportation',
+    'Food',
+    'Healthcare',
+    'Entertainment',
+    'Shopping',
+    'Bills',
+    'Education',
+    'Travel',
+    'Other'
+] as const;
+
+export const RECURRING_FREQUENCIES = [
+    'Weekly',
+    'Bi-weekly',
+    'Monthly',
+    'Quarterly',
+    'Yearly'
+] as const;
+
+// Utility types
+export type ExpenseCategory = typeof EXPENSE_CATEGORIES[number];
+export type RecurringFrequency = typeof RECURRING_FREQUENCIES[number];
+
+// Shared Expense types
+export interface BaseExpense {
+    amount: number;
+    dateSpent: Date;
+    description?: string;
+    category: ExpenseCategory;
+    merchant?: string;
+    isRecurring: boolean;
+    recurringFrequency?: RecurringFrequency;
+    startDate?: Date;
+}
+
+// Mongoose Document interface for Expense
+export interface IExpense extends Document, BaseExpense {
+    userId: mongoose.Types.ObjectId;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+const expenseSchema = new Schema<IExpense>({
+    userId: { 
+        type: Schema.Types.ObjectId, 
+        ref: 'User', 
+        required: true 
+    },
+    amount: { 
+        type: Number, 
+        required: true,
+        min: [0, 'Amount must be positive']
+    },
+    dateSpent: { 
+        type: Date, 
+        required: true,
+        default: Date.now
+    },
+    description: { 
+        type: String
+    },
+    category: { 
+        type: String, 
+        required: true,
+        enum: EXPENSE_CATEGORIES,
+        default: 'Other'
+    },
+    merchant: { 
+        type: String, 
+    },
+    isRecurring: { 
+        type: Boolean, 
+        default: false 
+    },
+    recurringFrequency: { 
+        type: String,
+        enum: RECURRING_FREQUENCIES,
+        required: function(this: IExpense) {
+            return this.isRecurring;
+        }
+    },
+    startDate: { 
+        type: Date,
+        required: function(this: IExpense) {
+            return this.isRecurring;
+        }
+    }
+}, {
+    timestamps: true
+});
+
+// This is the syntax for adding static methods
+expenseSchema.statics.findByUserId = function(userId: string) {
+    return this.find({ userId }).sort({ dateSpent: -1 });
+};
+
+expenseSchema.statics.findRecurringExpenses = function(userId: string) {
+    return this.find({ userId, isRecurring: true });
+};
+
+expenseSchema.statics.getTotalExpenseForPeriod = function(userId: string, startDate: Date, endDate: Date) {
+    return this.aggregate([
+        {
+            $match: {
+                userId: new mongoose.Types.ObjectId(userId),
+                dateSpent: { $gte: startDate, $lte: endDate }
+            }
+        },
+        {
+            $group: {
+                _id: null,
+                totalAmount: { $sum: '$amount' },
+                count: { $sum: 1 }
+            }
+        }
+    ]);
+};
+
+// Define the model interface with static methods
+interface IExpenseModel extends Model<IExpense> {
+    findByUserId(userId: string): Promise<IExpense[]>;
+    findRecurringExpenses(userId: string): Promise<IExpense[]>;
+    getTotalExpenseForPeriod(userId: string, startDate: Date, endDate: Date): Promise<any[]>;
+}
+
+// Create and export the model, to be new'd up in controllers.
+const Expense: IExpenseModel = mongoose.model<IExpense, IExpenseModel>('Expense', expenseSchema);
+
+// Export the model
+export default Expense;


### PR DESCRIPTION
This pull request introduces a new Mongoose model for managing expenses in the backend. The model includes schema definitions, type safety with TypeScript, validation, and several helpful static methods for querying expense data.

**Expense model and schema definition:**

* Added a new file `backend/models/Expense.ts` that defines the `Expense` Mongoose model, including the schema for expenses with fields such as `amount`, `dateSpent`, `category`, `isRecurring`, and related validation rules.
* Introduced TypeScript types and interfaces (`ExpenseCategory`, `RecurringFrequency`, `BaseExpense`, `IExpense`) to ensure type safety throughout the codebase.
* Defined constants for allowed expense categories and recurring frequencies to standardize input and validation.

**Static methods for querying expenses:**

* Implemented static methods on the model for common queries: `findByUserId`, `findRecurringExpenses`, and `getTotalExpenseForPeriod`, enabling efficient querying and aggregation of expense data per user.

**Export and usage:**

* Exported the `Expense` model for use in controllers and other parts of the backend.